### PR TITLE
Output format 'prtg' added

### DIFF
--- a/check_pgbackrest
+++ b/check_pgbackrest
@@ -291,20 +291,22 @@ sub prtg_output ($$;$$) {
     $text .= $service . " CRITICAL" if $rc == 2;
     $text .= $service . " UNKNOWN"  if $rc == 3;
 
-    $results = "<result><channel>status</channel><value>$rc</value></result>";
+    $results = "<result><channel>status</channel><value>$rc</value>";
+    $results .= "<LimitMaxWarning>0</LimitMaxWarning>";
+    $results .= "<LimitMaxError>1</LimitMaxError>";
+    $results .= "<LimitMode>1</LimitMode></result>";
     
     @msg      = @{ $_[0] } if defined $_[0];
     @longmsg  = @{ $_[1] } if defined $_[1];
     foreach my $msg_to_split (@longmsg) {
         my ($key, $value) = split(/=/, $msg_to_split);
-        my $val;
         if ($key eq "latest") { # is string, goes into <Text> element
             $text .= "\nLatest backup: ". $value;
         } elsif ($key =~ m/^latest.*age$/) {
             chop($value);
             $results .= "<result><channel>$key</channel><value>$value</value>";
             $results .= "<Unit>TimeSeconds</Unit></result>"
-        } elsif ($key eq "latest_full") { # ist string, goes into <Text> element
+        } elsif ($key eq "latest_full") { # is string, goes into <Text> element
             $text .= "\nLatest full backup: ". $value;
         } else {
             $results .= "<result><channel>$key</channel><value>$value</value>";

--- a/check_pgbackrest
+++ b/check_pgbackrest
@@ -276,6 +276,47 @@ sub nagios_output ($$;$$) {
     return $rc;
 }
 
+sub prtg_output ($$;$$) {
+    my $rc  = shift;
+    my $service = shift;
+    my $ret;
+    my @msg;
+    my @longmsg;
+    my $results;
+    my $text;
+
+    $text = "<text>";
+    $text .= $service . " OK"       if $rc == 0;
+    $text .= $service . " WARNING"  if $rc == 1;
+    $text .= $service . " CRITICAL" if $rc == 2;
+    $text .= $service . " UNKNOWN"  if $rc == 3;
+
+    $results = "<result><channel>status</channel><value>$rc</value></result>";
+    
+    @msg      = @{ $_[0] } if defined $_[0];
+    @longmsg  = @{ $_[1] } if defined $_[1];
+    foreach my $msg_to_split (@longmsg) {
+        my ($key, $value) = split(/=/, $msg_to_split);
+        my $val;
+        if ($key eq "latest") { # is string, goes into <Text> element
+            $text .= "\nLatest backup: ". $value;
+        } elsif ($key =~ m/^latest.*age$/) {
+            chop($value);
+            $results .= "<result><channel>$key</channel><value>$value</value>";
+            $results .= "<Unit>TimeSeconds</Unit></result>"
+        } elsif ($key eq "latest_full") { # ist string, goes into <Text> element
+            $text .= "\nLatest full backup: ". $value;
+        } else {
+            $results .= "<result><channel>$key</channel><value>$value</value>";
+            $results .= "<Unit>Count</Unit></result>"
+        }
+    }
+
+    $text .= "</text>";
+    print "<prtg>" . $results . $text. "</prtg>";
+    return $rc;
+}
+
 # Handle time intervals
 #-----------------------------------------------------------------------------
 
@@ -330,7 +371,7 @@ sub to_interval_output_dependent($) {
 
     return $val if $val =~ /^-?inf/i;
     $val = int($val);
-    return to_interval($val) unless $args{'output'} =~ /^nagios$/;
+    return to_interval($val) unless $args{'output'} =~ /^(nagios|prtg)$/;
     return "${val}s";
 }
 
@@ -1105,6 +1146,7 @@ for ( $args{'output'} ) {
        if ( /^human$/         ) { $output_fmt = \&human_output  }
     elsif ( /^json$/        ) { $output_fmt = \&json_output }
     elsif ( /^nagios$/        ) { $output_fmt = \&nagios_output }
+    elsif ( /^prtg$/        ) { $output_fmt = \&prtg_output }
     else {
         pod2usage(
             -message => "FATAL: unrecognized output format \"$_\" (see \"--output\")",


### PR DESCRIPTION
Dear Stefan,
I'm using [PRTG](https://www.paessler.com/prtg) for monitoring and your check_pgbackrest was exactly what I needed. Thanks for this nice tool!
I added therefore another output format to suit the [PRTG advanced sensors](https://www.paessler.com/manuals/prtg/custom_sensors#advanced_sensors) format.
I successfully added a sensor for my PostgreSQL Backups.
I'm not a real perl coder, but my code seems to work fine. Would you please consider to integrate my contribution?

Thanks and kind regards!
Hans-Peter
![ksnip_20210707-114619](https://user-images.githubusercontent.com/15996066/124738469-3f0e2480-df19-11eb-91e4-6c1ae9bb4b18.png)
